### PR TITLE
cleanup | Pod version fixed, now 0.2.7.

### DIFF
--- a/ReactiveCocoaApply.podspec
+++ b/ReactiveCocoaApply.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "ReactiveCocoaApply"
-  s.version          = "0.2.6"
+  s.version          = "0.2.7"
   s.summary          = "ReactiveCocoa Singal and SignalProducer extensions for RAC4 for applying operators similar to |> from RAC3."
 
   s.homepage         = "https://github.com/nikita-leonov/ReactiveCocoaApply"


### PR DESCRIPTION
Please create new release for v0.2.7 ( https://help.github.com/articles/creating-releases/ ).

There was an inconsistency: tag v0.2.6 with Podspec version 0.2.5.
